### PR TITLE
Include elm-live in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ A front end UI for declarative syntax rewriting using [comby](https://github.com
 The view is mocked until you launch a rewrite server. See [comby](https://github.com/comby-tools/comby).
 
 - Install [elm 0.18](https://github.com/elm-lang/elm-platform/releases/tag/0.18.0-exp).
+- Install [elm-live for elm 0.18](https://github.com/wking-io/elm-live#if-you-are-using-elm-018)
 - run `./configure.sh <port-you-want-to-serve-on> <port-of-comby-server>`
 - `make`


### PR DESCRIPTION
This wasn't a big issue because the error message was straightforward, but it might still help someone else.