### PR TITLE
Add quotes to the terminal output template

### DIFF
--- a/Controller.elm
+++ b/Controller.elm
@@ -36,18 +36,18 @@ terminalCommand model extraOption =
                 s
 
         matchTemplate =
-            "COMBY_M=$(cat <<\"MATCH\"\n"
+            "COMBY_M=\"$(cat <<\"MATCH\"\n"
                 ++ model.matchTemplateInput
-                ++ "\nMATCH\n)\n"
+                ++ "\nMATCH\n)\"\n"
 
         ( rewriteTemplateEnv, rewriteVar ) =
             if model.rewriteTemplateInput == "" then
                 ( "", "''" )
 
             else
-                ( "COMBY_R=$(cat <<\"REWRITE\"\n"
+                ( "COMBY_R=\"$(cat <<\"REWRITE\"\n"
                     ++ model.rewriteTemplateInput
-                    ++ "\nREWRITE\n)\n"
+                    ++ "\nREWRITE\n)\"\n"
                 , "$COMBY_R"
                 )
 
@@ -56,9 +56,9 @@ terminalCommand model extraOption =
                 ( "", "" )
 
             else
-                ( "COMBY_RULE=$(cat <<\"RULE\"\n"
+                ( "COMBY_RULE=\"$(cat <<\"RULE\"\n"
                     ++ model.ruleInput
-                    ++ "\nRULE\n)\n"
+                    ++ "\nRULE\n)\"\n"
                 , " -rule $COMBY_RULE"
                 )
 


### PR DESCRIPTION
I noticed that the command provided doesn't seem to work in bash, at least on my Mac. I found that by surrounding the sub-shells with quotes I could get it to work. My guess is that it worked before on zsh? Presumably this will as well.

```
COMBY_M="$(cat <<"MATCH"
class :[name]
MATCH
)"
COMBY_R="$(cat <<"REWRITE"
classy :[name]ish
REWRITE
)"
# the next line installs comby if you need it :)
bash <(curl -sL 0.comby.dev) && \
comby $COMBY_M $COMBY_R  .go -stats
```