### PR TITLE
Show an install message, but don't run anything

### DIFF
--- a/Controller.elm
+++ b/Controller.elm
@@ -63,8 +63,7 @@ terminalCommand model extraOption =
                 )
 
         zeroInstall =
-            "# the next line installs comby if you need it :)\n"
-                ++ "bash <(curl -sL 0.comby.dev) && \\\n"
+            "# Install comby with `bash <(curl -sL get.comby.dev)` or see github.com/comby-tools/comby && \\\n"
 
         text =
             if model.matchTemplateInput == "" then


### PR DESCRIPTION
Removes running the `0-install` command, since this is likely to bite people who are on a distribution other than those for the binary release.