### PR TITLE
adding monospace font as fallback to Monaco

### DIFF
--- a/dark-theme/custom.css
+++ b/dark-theme/custom.css
@@ -165,13 +165,13 @@ match_template {
 
 textarea
 {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     spellcheck:false;
     font-size:14px !important;
 }
 
 pre code {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     font-size:14px;
 }
 
@@ -182,7 +182,7 @@ pre {
 }
 
 .rule-syntax-errors {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     white-space: pre-wrap;
     font-size:12px;
     margin:0px;

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -165,13 +165,13 @@ match_template {
 
 textarea
 {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     spellcheck:false;
     font-size:14px !important;
 }
 
 pre code {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     font-size:14px;
 }
 
@@ -182,7 +182,7 @@ pre {
 }
 
 .rule-syntax-errors {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     white-space: pre-wrap;
     font-size:12px;
     margin:0px;

--- a/light-theme/custom.css
+++ b/light-theme/custom.css
@@ -64,13 +64,13 @@ match_template {
 
 textarea
 {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     spellcheck:false;
     font-size:14px !important;
 }
 
 pre code {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     font-size:14px;
 }
 
@@ -81,7 +81,7 @@ pre {
 }
 
 .rule-syntax-errors {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     white-space: pre-wrap;
     font-size:12px;
     margin:0px;

--- a/staging/custom.css
+++ b/staging/custom.css
@@ -165,13 +165,13 @@ match_template {
 
 textarea
 {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     spellcheck:false;
     font-size:14px !important;
 }
 
 pre code {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     font-size:14px;
 }
 
@@ -182,7 +182,7 @@ pre {
 }
 
 .rule-syntax-errors {
-    font-family:"Monaco";
+    font-family:"Monaco", monospace;
     white-space: pre-wrap;
     font-size:12px;
     margin:0px;


### PR DESCRIPTION
Hi,

I noticed that the code in input/output areas was not showing up with fixed-width on my computer. That felt weird, and upon investigating, I figured out it is because I didn't have the "Monaco" font installed in my computer for some reason.

Anyway, this PR helps avoiding this problem by having a second option for monospaced font declared in the css. The "monospace" in font-family is a [special case](https://www.w3.org/TR/CSS2/fonts.html#generic-font-families) that instructs the browser to use whatever it has configured as fixed-width font